### PR TITLE
Use in-memory signal for openSMILE features

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,10 +122,10 @@ def extract_features(
 
     # --- 2) Voicing & pitch steadiness (openSMILE functionals) ---
     if lock is None:
-        f = smile.process_file(wav_path)  # 1 row
+        f = smile.process_signal(y, sr)  # 1 row
     else:
         with lock:
-            f = smile.process_file(wav_path)
+            f = smile.process_signal(y, sr)
 
     def pick(regex: str) -> float:
         cols = f.filter(regex=regex).columns


### PR DESCRIPTION
## Summary
- switch openSMILE feature extraction to `process_signal` to reuse the audio loaded with librosa

## Testing
- `python test.py` *(fails: f0_std diff 31.801831245422363 exceeds tolerance 0.05)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b6390fc4832d948bd9f1d207b529